### PR TITLE
Use full model name instead of shortcut

### DIFF
--- a/code/preprocess_cam.py
+++ b/code/preprocess_cam.py
@@ -21,7 +21,7 @@ class WhitespaceTokenizer(object):
         spaces = [True] * len(words)
         return Doc(self.vocab, words=words, spaces=spaces)
 
-nlp = spacy.load('en',disable=['tagger','ner'],vectors=False)
+nlp = spacy.load('en_core_web_sm',disable=['tagger','ner'],vectors=False)
 nlp.tokenizer = WhitespaceTokenizer(nlp.vocab)
 
 def get_args():

--- a/code/preprocess_dstc2.py
+++ b/code/preprocess_dstc2.py
@@ -20,7 +20,7 @@ class WhitespaceTokenizer(object):
         spaces = [True] * len(words)
         return Doc(self.vocab, words=words, spaces=spaces)
 
-nlp = spacy.load('en',disable=['tagger','ner'],vectors=False)
+nlp = spacy.load('en_core_web_sm',disable=['tagger','ner'],vectors=False)
 nlp.tokenizer = WhitespaceTokenizer(nlp.vocab)
 
 def get_args():


### PR DESCRIPTION
Hi,

This PR fixes one of the major issues in spacy. Sometimes users may not create shortcut to the downloaded model. In that case, loading model using shortcut throws an error. Hence, I changed to loading to model name.